### PR TITLE
Missing delimiter in ArrayUtility

### DIFF
--- a/Classes/Configuration/ConfigurationContainer.php
+++ b/Classes/Configuration/ConfigurationContainer.php
@@ -60,7 +60,7 @@ class ConfigurationContainer implements ConfigurationContainerInterface
      */
     public function get(string $path)
     {
-        $value = ArrayUtility::getValueByPath($this->settings, $path);
+        $value = ArrayUtility::getValueByPath($this->settings, $path, '.');
 
         if ($value === null) {
             throw new InvalidArgumentException(
@@ -78,6 +78,6 @@ class ConfigurationContainer implements ConfigurationContainerInterface
      */
     public function getIfExists(string $path)
     {
-        return ArrayUtility::getValueByPath($this->settings, $path);
+        return ArrayUtility::getValueByPath($this->settings, $path, '.');
     }
 }


### PR DESCRIPTION
The standard delimiter is '/' but we need it to be in dot notation.
This should be covered by an unit test.